### PR TITLE
EE-000: ezui

### DIFF
--- a/packages/easy-ui/package.json
+++ b/packages/easy-ui/package.json
@@ -12,11 +12,6 @@
       "import": "./dist/es/next.js",
       "require": "./dist/lib/next.js",
       "types": "./dist/types/next.d.ts"
-    },
-    "./icon": {
-      "import": "./dist/es/icon.js",
-      "require": "./dist/lib/icon.js",
-      "types": "./dist/types/icon.d.ts"
     }
   },
   "scripts": {

--- a/packages/easy-ui/rollup.config.js
+++ b/packages/easy-ui/rollup.config.js
@@ -26,7 +26,7 @@ module.exports = [
     input: {
       index: './src/index.ts',
       next: './src/next.ts',
-      icon: './src/icon.ts',
+      // icon: './src/icon.ts',
     },
     output: [
       {
@@ -68,7 +68,7 @@ module.exports = [
     input: {
       index: './src/index.ts',
       next: './src/next.ts',
-      icon: './src/icon.ts',
+      // icon: './src/icon.ts',
     },
     output: {
       dir: 'dist/types',

--- a/packages/easy-ui/src/EzIcon/EzIcon.tsx
+++ b/packages/easy-ui/src/EzIcon/EzIcon.tsx
@@ -1,0 +1,25 @@
+import { SvgIcon, SvgIconProps } from '@mui/material';
+
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+
+export const iconMapping = {
+  Visibility: Visibility,
+  VisibilityOff: VisibilityOff,
+} as const;
+
+export type EzIconName = keyof typeof iconMapping;
+
+export const getEzIcon = (name: EzIconName) => {
+  if (!iconMapping[name]) console.warn(`No icon name mapping for: ${name}`);
+  const Ikon: typeof SvgIcon = iconMapping[name];
+  return Ikon;
+};
+
+export interface EzIconProps extends Omit<SvgIconProps, 'name' | 'muiName'> {
+  name: EzIconName;
+}
+
+export function EzIcon({ name, ...props }: EzIconProps) {
+  const Icon_ = getEzIcon(name);
+  return <Icon_ {...props} />;
+}

--- a/packages/easy-ui/src/EzIcon/index.ts
+++ b/packages/easy-ui/src/EzIcon/index.ts
@@ -1,0 +1,1 @@
+export * from './EzIcon';

--- a/packages/easy-ui/src/EzIconButton/EzIconButton.tsx
+++ b/packages/easy-ui/src/EzIconButton/EzIconButton.tsx
@@ -1,0 +1,3 @@
+export function EzIconButton() {
+  return <div>EzIconButton</div>;
+}

--- a/packages/easy-ui/src/EzIconButton/index.ts
+++ b/packages/easy-ui/src/EzIconButton/index.ts
@@ -1,0 +1,1 @@
+export * from './EzIconButton';

--- a/packages/easy-ui/src/EzTextField/EzTextField.tsx
+++ b/packages/easy-ui/src/EzTextField/EzTextField.tsx
@@ -1,8 +1,13 @@
 import styled from '@emotion/styled';
-import { TextField, TextFieldProps } from '@mui/material';
+import { InputAdornment, TextField, TextFieldProps } from '@mui/material';
+import { ReactNode } from 'react';
 import { Controller, UseControllerProps, useController } from 'react-hook-form';
 
-type EzTextFieldProps = Omit<TextFieldProps, 'name' | 'value' | 'defaultValue'> & UseControllerProps;
+type EzTextFieldProps = Omit<TextFieldProps, 'name' | 'value' | 'defaultValue'> &
+  UseControllerProps & {
+    startAdornment?: ReactNode;
+    endAdornment?: ReactNode;
+  };
 
 const StyledTextField = styled(TextField)<EzTextFieldProps>(() => ({
   variant: 'standard',
@@ -10,7 +15,8 @@ const StyledTextField = styled(TextField)<EzTextFieldProps>(() => ({
 }));
 
 export function EzTextField(props: EzTextFieldProps) {
-  const { control, name, rules, defaultValue, shouldUnregister, ...componentProps } = props;
+  const { control, name, rules, defaultValue, shouldUnregister, startAdornment, endAdornment, ...componentProps } =
+    props;
   const controllerParams = { control, name, rules, defaultValue, shouldUnregister };
   const { fieldState } = useController(controllerParams);
 
@@ -27,6 +33,14 @@ export function EzTextField(props: EzTextFieldProps) {
           variant={variant}
           helperText={fieldState.error?.message ?? ''}
           error={Boolean(fieldState.error)}
+          InputProps={{
+            ...(startAdornment && {
+              startAdornment: <InputAdornment position="start">{startAdornment}</InputAdornment>,
+            }),
+            ...(endAdornment && {
+              endAdornment: <InputAdornment position="end">{endAdornment}</InputAdornment>,
+            }),
+          }}
         />
       )}
     />

--- a/packages/easy-ui/src/icon.ts
+++ b/packages/easy-ui/src/icon.ts
@@ -1,1 +1,0 @@
-export * from '@mui/icons-material';

--- a/packages/easy-ui/src/index.ts
+++ b/packages/easy-ui/src/index.ts
@@ -3,4 +3,5 @@ export * from '@mui/material';
 export * from './EzForm';
 
 export * from './EzCheckbox';
+export * from './EzIcon';
 export * from './EzTextField';

--- a/packages/easy-ui/src/stories/Page.tsx
+++ b/packages/easy-ui/src/stories/Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { FC, useState } from 'react';
 
 import { Header } from './Header';
 import './page.css';
@@ -7,8 +7,8 @@ type User = {
   name: string;
 };
 
-export const Page: React.FC = () => {
-  const [user, setUser] = React.useState<User>();
+export const Page: FC = () => {
+  const [user, setUser] = useState<User>();
 
   return (
     <article>
@@ -29,18 +29,16 @@ export const Page: React.FC = () => {
           process starting with atomic components and ending with pages.
         </p>
         <p>
-          Render pages with mock data. This makes it easy to build and review page states without
-          needing to navigate to them in your app. Here are some handy patterns for managing page
-          data in Storybook:
+          Render pages with mock data. This makes it easy to build and review page states without needing to navigate to
+          them in your app. Here are some handy patterns for managing page data in Storybook:
         </p>
         <ul>
           <li>
-            Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            Use a higher-level connected component. Storybook helps you compose such data from the "args" of child
+            component stories
           </li>
           <li>
-            Assemble data in the page component from your services. You can mock these services out
-            using Storybook.
+            Assemble data in the page component from your services. You can mock these services out using Storybook.
           </li>
         </ul>
         <p>

--- a/packages/frontend/src/modules/Auth/views/Login.tsx
+++ b/packages/frontend/src/modules/Auth/views/Login.tsx
@@ -9,7 +9,6 @@ import {
   EzForm,
   EzTextField,
   EzCheckbox,
-  InputAdornment,
   IconButton,
 } from '@ease-trip/easy-ui';
 import { Visibility, VisibilityOff } from '@ease-trip/easy-ui/icon';
@@ -18,67 +17,70 @@ import type { LoginForm } from '../models';
 import { useState } from 'react';
 
 export default function LoginPage() {
-    const router = useRouter();
+  const router = useRouter();
 
-    const [showPassword, setShowPassword] = useState(false);
-    const handleClickShowPassword = () => setShowPassword((show) => !show);
-    const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
-      event.preventDefault();
-    };
-  
-    async function handleSubmit(data: LoginForm) {
-      const { email, password } = data;
-  
-      try {
-        const response = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email, password }),
-        });
-  
-        const payload = await response.json();
-        if (response.ok) {
-          router.push('/plan');
-        } else {
-          // Handle errors
-          throw Error(payload);
-        }
-      } catch (err) {
-        if (err instanceof Error) {
-        }
+  const [showPassword, setShowPassword] = useState(false);
+  const handleClickShowPassword = () => setShowPassword((show) => !show);
+  const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
+
+  async function handleSubmit(data: LoginForm) {
+    const { email, password } = data;
+
+    try {
+      const response = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const payload = await response.json();
+      if (response.ok) {
+        router.push('/plan');
+      } else {
+        // Handle errors
+        throw Error(payload);
+      }
+    } catch (err) {
+      if (err instanceof Error) {
       }
     }
-  
-    return (
-      <Dialog open>
-        <DialogTitle>Ease Trip</DialogTitle>
-        <DialogContent>
-          <Grid rowSpacing={2}>
-            <EzForm defaultValues={defaultValues} schema={loginSchema} onSubmit={handleSubmit}>
-              <EzTextField fullWidth name="email" label="Email" />
-              <EzTextField fullWidth name="password" label="Password" InputProps={{
-                type: showPassword ? 'text' : 'password', 
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      aria-label="toggle password visibility"
-                      onClick={handleClickShowPassword}
-                      onMouseDown={handleMouseDownPassword}
-                    >
-                      {showPassword ? <VisibilityOff /> : <Visibility />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              }} />
-              <EzCheckbox name="rememberMe" label="keep me signed in." />
-              <DialogActions>
-                <Button variant="contained" type="submit">
-                  Sign In
-                </Button>
-              </DialogActions>
-            </EzForm>
-          </Grid>
-        </DialogContent>
-      </Dialog>
-    );
   }
+
+  return (
+    <Dialog open>
+      <DialogTitle>Ease Trip</DialogTitle>
+      <DialogContent>
+        <Grid rowSpacing={2}>
+          <EzForm defaultValues={defaultValues} schema={loginSchema} onSubmit={handleSubmit}>
+            <EzTextField fullWidth name="email" label="Email" />
+            <EzTextField
+              fullWidth
+              name="password"
+              label="Password"
+              type={showPassword ? 'text' : 'password'}
+              endAdornment={
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={handleClickShowPassword}
+                  onMouseDown={handleMouseDownPassword}
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              }
+            />
+
+            <EzCheckbox name="rememberMe" label="keep me signed in." />
+
+            <DialogActions>
+              <Button variant="contained" type="submit">
+                Sign In
+              </Button>
+            </DialogActions>
+          </EzForm>
+        </Grid>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/frontend/src/modules/Auth/views/Login.tsx
+++ b/packages/frontend/src/modules/Auth/views/Login.tsx
@@ -1,3 +1,4 @@
+import { MouseEvent as ReactMouseEvent, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
   Button,
@@ -9,19 +10,19 @@ import {
   EzForm,
   EzTextField,
   EzCheckbox,
+  EzIcon,
   IconButton,
 } from '@ease-trip/easy-ui';
-import { Visibility, VisibilityOff } from '@ease-trip/easy-ui/icon';
+// import { Visibility, VisibilityOff } from '@ease-trip/easy-ui/icon';
 import { defaultValues, loginSchema } from '../models';
 import type { LoginForm } from '../models';
-import { useState } from 'react';
 
 export default function LoginPage() {
   const router = useRouter();
 
   const [showPassword, setShowPassword] = useState(false);
   const handleClickShowPassword = () => setShowPassword((show) => !show);
-  const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleMouseDownPassword = (event: ReactMouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
   };
 
@@ -66,7 +67,7 @@ export default function LoginPage() {
                   onClick={handleClickShowPassword}
                   onMouseDown={handleMouseDownPassword}
                 >
-                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                  <EzIcon name={showPassword ? 'VisibilityOff' : 'Visibility'} />
                 </IconButton>
               }
             />


### PR DESCRIPTION
- Add `startAdornment` and `endAdornment` to EzTextField
- Add `EzIcon`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `EzIcon` 组件中添加了基于提供的 `name` 属性动态渲染图标的功能。
	- 引入了 `EzIconButton` 组件，它渲染一个简单的显示文本 "EzIconButton" 的 `<div>` 元素。
	- `EzTextField` 组件现在接受 `startAdornment` 和 `endAdornment` 作为属性，允许在输入字段中添加额外的装饰。
	- 登录页面现在使用 `EzIcon` 替换了密码可见性图标，并更新了密码可见性切换的 `EzTextField` 属性。

- **文档**
	- 更新了 `Page` 组件的文档，包括使用 `useState` 而不是导入整个 'react' 模块，以及使用 `FC` 替代 `React.FC`。

- **重构**
	- 在构建过程中，暂时注释了 `icon` 输入路径的配置，影响了输出目录的构建过程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->